### PR TITLE
Fix: Correct chess rule implementations and add features

### DIFF
--- a/board.lua
+++ b/board.lua
@@ -24,7 +24,8 @@ function board.initialize()
                     type = layout[row][col],
                     color = color,
                     row = row,
-                    col = col
+                    col = col,
+                    has_moved = false -- Initialize has_moved flag
                 }
             end
         end

--- a/chess_rules.lua
+++ b/chess_rules.lua
@@ -50,8 +50,20 @@ function chess_rules.isValidMove(pieces, piece, newRow, newCol)
                     return true
                 end
             end
-        elseif math.abs(colDiff) == 1 and rowDiff == direction and targetPiece then
-            return true
+        elseif math.abs(colDiff) == 1 and rowDiff == direction then -- Diagonal move
+            if targetPiece and targetPiece.color ~= piece.color then -- Normal capture
+                return true
+            elseif not targetPiece then -- Potential en passant
+                if _G.lastMove and _G.lastMove.isTwoSquarePawnAdvance and
+                   _G.lastMove.piece.type == "pawn" and _G.lastMove.piece.color ~= piece.color and
+                   _G.lastMove.toRow == piece.row and _G.lastMove.toCol == newCol then
+                    -- The opponent's pawn (_G.lastMove.piece) landed adjacent (piece.row, newCol)
+                    -- And the current pawn is attacking the square it skipped over
+                    if newRow == piece.row + direction then
+                        return { en_passant = true, captured_pawn_pos = {row = _G.lastMove.toRow, col = _G.lastMove.toCol} }
+                    end
+                end
+            end
         end
     elseif piece.type == "rook" then
         if rowDiff == 0 or colDiff == 0 then
@@ -69,7 +81,77 @@ function chess_rules.isValidMove(pieces, piece, newRow, newCol)
             return chess_rules.isPathClear(pieces, piece.row, piece.col, newRow, newCol)
         end
     elseif piece.type == "king" then
-        return math.abs(rowDiff) <= 1 and math.abs(colDiff) <= 1
+        -- Normal King Move
+        if math.abs(rowDiff) <= 1 and math.abs(colDiff) <= 1 then
+            return true
+        end
+
+        -- Castling Logic
+        if rowDiff == 0 and math.abs(colDiff) == 2 and not piece.has_moved then
+            if chess_rules.isKingInCheck(pieces, piece.color) then
+                return false -- Cannot castle while in check
+            end
+
+            local kingside = colDiff > 0
+            local rook_col = kingside and config.BOARD_SIZE or 1
+            local rook = pieces[piece.row][rook_col]
+
+            if not rook or rook.type ~= "rook" or rook.color ~= piece.color or rook.has_moved then
+                return false -- Rook missing, wrong type, wrong color, or has moved
+            end
+
+            local opponent_color = piece.color == "white" and "black" or "white"
+
+            -- Check path clear and squares not under attack
+            if kingside then -- Kingside castling (O-O) King to G, Rook to F
+                -- Path for king: E to G (F, G must be clear). Rook path: H to F (G, F must be clear)
+                -- Squares king passes/lands on: F, G (cols piece.col+1, piece.col+2)
+                if pieces[piece.row][piece.col + 1] or pieces[piece.row][piece.col + 2] then
+                    return false -- Path not clear between king and king's destination
+                end
+                -- Check squares king passes through/lands on for attack
+                if chess_rules.isSquareUnderAttack(pieces, piece.row, piece.col + 1, opponent_color) or
+                   chess_rules.isSquareUnderAttack(pieces, piece.row, piece.col + 2, opponent_color) then
+                    return false
+                end
+                -- Also ensure rook's path from its original position to its destination is clear
+                -- (only piece.col+1 needs to be clear for the rook if king moves to piece.col+2)
+                -- This is implicitly covered by pieces[piece.row][piece.col + 1] == nil for king's path.
+
+                return { castling_details = {
+                    kingside = true,
+                    rook_original_col = rook_col,
+                    rook_target_col = piece.col + 1 -- Rook moves to F (col 6 if king on E=5)
+                }}
+            else -- Queenside castling (O-O-O) King to C, Rook to D
+                -- Path for king: E to C (D, C must be clear). Rook path: A to D (B, C, D must be clear)
+                -- Squares king passes/lands on: D, C (cols piece.col-1, piece.col-2)
+                if pieces[piece.row][piece.col - 1] or pieces[piece.row][piece.col - 2] or (config.BOARD_SIZE == 8 and pieces[piece.row][piece.col - 3]) then -- piece.col-3 is B file, only if rook needs to pass it
+                    return false -- Path not clear
+                end
+                 -- Check squares king passes through/lands on for attack
+                if chess_rules.isSquareUnderAttack(pieces, piece.row, piece.col - 1, opponent_color) or
+                   chess_rules.isSquareUnderAttack(pieces, piece.row, piece.col - 2, opponent_color) then
+                    return false
+                end
+                -- Rook path from A to D (cols 1 to 4 if king on E=5, king moves to C=3)
+                -- Squares B, C, D (cols piece.col-3, piece.col-2, piece.col-1) must be clear for rook
+                -- This check: pieces[piece.row][piece.col - 1], pieces[piece.row][piece.col - 2] already done.
+                -- pieces[piece.row][piece.col - 3] (B file) also needs to be clear for rook to pass.
+                -- The condition above (config.BOARD_SIZE == 8 and pieces[piece.row][piece.col - 3]) handles the B file check.
+                -- If board size is not 8, this specific piece.col-3 might be out of bounds or not relevant.
+                -- For a standard 8x8 board, queen-side castling has king on e1, rook on a1. King moves to c1, rook to d1.
+                -- Path for king: d1, c1. Path for rook: b1, c1, d1.
+                -- Squares to be empty: b1, c1, d1 (cols 2,3,4 if king at 5) or (king.col-3, king.col-2, king.col-1)
+                -- The check `(config.BOARD_SIZE == 8 and pieces[piece.row][piece.col - 3])` is correct for the B file for queenside.
+
+                return { castling_details = {
+                    kingside = false,
+                    rook_original_col = rook_col,
+                    rook_target_col = piece.col - 1 -- Rook moves to D (col 4 if king on E=5)
+                }}
+            end
+        end
     end
     
     return false
@@ -92,14 +174,26 @@ function chess_rules.isSquareUnderAttack(pieces, targetRow, targetCol, byColor)
         for col = 1, config.BOARD_SIZE do
             local piece = pieces[row][col]
             if piece and piece.color == byColor then
-                local tempPiece = {
-                    type = piece.type,
-                    color = piece.color,
-                    row = row,
-                    col = col
-                }
-                if chess_rules.isValidMove(pieces, tempPiece, targetRow, targetCol) then
-                    return true
+                if piece.type == "pawn" then
+                    local direction = piece.color == "white" and -1 or 1
+                    -- Check left diagonal attack
+                    if targetRow == piece.row + direction and targetCol == piece.col - 1 then
+                        return true -- Square is attacked by this pawn
+                    end
+                    -- Check right diagonal attack
+                    if targetRow == piece.row + direction and targetCol == piece.col + 1 then
+                        return true -- Square is attacked by this pawn
+                    end
+                else -- For other pieces, use the existing isValidMove logic
+                    local tempPiece = {
+                        type = piece.type,
+                        color = piece.color,
+                        row = row,
+                        col = col
+                    }
+                    if chess_rules.isValidMove(pieces, tempPiece, targetRow, targetCol) then
+                        return true
+                    end
                 end
             end
         end
@@ -115,43 +209,165 @@ function chess_rules.isKingInCheck(pieces, color)
     return chess_rules.isSquareUnderAttack(pieces, king.row, king.col, enemyColor)
 end
 
-function chess_rules.wouldMoveLeaveKingInCheck(pieces, piece, newRow, newCol)
+function chess_rules.wouldMoveLeaveKingInCheck(pieces, piece, newRow, newCol, move_details)
     if not piece then return true end
     
     local originalRow = piece.row
     local originalCol = piece.col
+    local originalKingHasMoved = piece.has_moved -- Save king's has_moved state
     local capturedPiece = pieces[newRow][newCol]
     
+    local temp_en_passant_captured_pawn = nil
+    local en_passant_capture_pos = nil
+    local temp_castling_rook = nil
+    local originalRookPos = nil
+    local originalRookHasMoved = nil
+    local castling_rook_new_col = nil
+
+    -- Simulate move
     pieces[originalRow][originalCol] = nil
     pieces[newRow][newCol] = piece
     piece.row = newRow
     piece.col = newCol
+    piece.has_moved = true -- Simulate king has moved
+
+    if move_details then
+        if move_details.en_passant_details then
+            en_passant_capture_pos = move_details.en_passant_details.captured_pawn_pos
+            if pieces[en_passant_capture_pos.row] then
+                 temp_en_passant_captured_pawn = pieces[en_passant_capture_pos.row][en_passant_capture_pos.col]
+                 pieces[en_passant_capture_pos.row][en_passant_capture_pos.col] = nil
+            end
+        elseif move_details.castling_details then
+            local cd = move_details.castling_details
+            originalRookPos = {row = originalRow, col = cd.rook_original_col}
+            temp_castling_rook = pieces[originalRookPos.row][originalRookPos.col]
+            if temp_castling_rook then -- Rook should exist
+                originalRookHasMoved = temp_castling_rook.has_moved
+                castling_rook_new_col = cd.rook_target_col
+
+                pieces[originalRookPos.row][originalRookPos.col] = nil
+                pieces[originalRookPos.row][castling_rook_new_col] = temp_castling_rook
+                temp_castling_rook.col = castling_rook_new_col
+                temp_castling_rook.has_moved = true
+            end
+        end
+    end
     
     local inCheck = chess_rules.isKingInCheck(pieces, piece.color)
     
+    -- Undo the move
     pieces[originalRow][originalCol] = piece
     pieces[newRow][newCol] = capturedPiece
     piece.row = originalRow
     piece.col = originalCol
+    piece.has_moved = originalKingHasMoved -- Restore king's has_moved state
+
+    if en_passant_capture_pos and pieces[en_passant_capture_pos.row] then
+        pieces[en_passant_capture_pos.row][en_passant_capture_pos.col] = temp_en_passant_captured_pawn
+    end
+    if temp_castling_rook and originalRookPos then -- Undo castling rook move
+        pieces[originalRookPos.row][originalRookPos.col] = temp_castling_rook
+        if pieces[originalRookPos.row][castling_rook_new_col] == temp_castling_rook then -- if rook is still there
+             pieces[originalRookPos.row][castling_rook_new_col] = nil
+        end
+        temp_castling_rook.col = originalRookPos.col
+        temp_castling_rook.has_moved = originalRookHasMoved
+    end
     
     return inCheck
 end
 
 function chess_rules.getValidMoves(pieces, piece)
     local validMoves = {}
-    
     if not piece then return validMoves end
-    
-    for row = 1, config.BOARD_SIZE do
-        for col = 1, config.BOARD_SIZE do
-            if chess_rules.isValidMove(pieces, piece, row, col) and 
-               not chess_rules.wouldMoveLeaveKingInCheck(pieces, piece, row, col) then
-                table.insert(validMoves, {row = row, col = col, capture = pieces[row][col] ~= nil})
+
+    for r = 1, config.BOARD_SIZE do
+        for c = 1, config.BOARD_SIZE do
+            local move_validation_result = chess_rules.isValidMove(pieces, piece, r, c)
+            local current_move_details = {}
+
+            if type(move_validation_result) == "table" then
+                if move_validation_result.en_passant then
+                    current_move_details.en_passant_details = move_validation_result
+                elseif move_validation_result.castling_details then
+                    current_move_details.castling_details = move_validation_result
+                else
+                    -- Should not happen if table is only for special moves
+                    goto next_iteration
+                end
+            elseif move_validation_result ~= true then
+                -- isValidMove returned false
+                goto next_iteration
+            end
+            -- At this point, move_validation_result was true or a table with details
+
+            if not chess_rules.wouldMoveLeaveKingInCheck(pieces, piece, r, c, current_move_details) then
+                local move_entry = { row = r, col = c }
+                if current_move_details.en_passant_details then
+                    move_entry.en_passant_details = current_move_details.en_passant_details
+                    move_entry.capture = true
+                elseif current_move_details.castling_details then
+                    move_entry.castling_details = current_move_details.castling_details
+                    move_entry.capture = false -- Castling is not a capture
+                else
+                    -- Normal move
+                    move_entry.capture = (pieces[r][c] ~= nil and pieces[r][c].color ~= piece.color)
+                end
+                table.insert(validMoves, move_entry)
+            end
+            ::next_iteration::
+        end
+    end
+    return validMoves
+end
+
+function chess_rules.isCheckmate(pieces, color)
+    if not chess_rules.isKingInCheck(pieces, color) then
+        return false -- Not in check, so not checkmate
+    end
+
+    -- Iterate through all pieces of the given color
+    for row_iter = 1, config.BOARD_SIZE do
+        for col_iter = 1, config.BOARD_SIZE do
+            local current_piece = pieces[row_iter][col_iter]
+            if current_piece and current_piece.color == color then
+                -- Get all valid moves for this piece
+                local validMoves = chess_rules.getValidMoves(pieces, current_piece)
+                if #validMoves > 0 then
+                    -- Found a piece that can make a legal move
+                    return false -- Not checkmate
+                end
             end
         end
     end
-    
-    return validMoves
+
+    -- No piece can make a legal move to get out of check
+    return true -- Checkmate
+end
+
+function chess_rules.isStalemate(pieces, color)
+    if chess_rules.isKingInCheck(pieces, color) then
+        return false -- King is in check, so it's either checkmate or game continues
+    end
+
+    -- Iterate through all pieces of the given color
+    for row_iter = 1, config.BOARD_SIZE do
+        for col_iter = 1, config.BOARD_SIZE do
+            local current_piece = pieces[row_iter][col_iter]
+            if current_piece and current_piece.color == color then
+                -- Get all valid moves for this piece
+                local validMoves = chess_rules.getValidMoves(pieces, current_piece)
+                if #validMoves > 0 then
+                    -- Found a piece that can make a legal move
+                    return false -- Not stalemate
+                end
+            end
+        end
+    end
+
+    -- No piece can make a legal move, and king is not in check
+    return true -- Stalemate
 end
 
 return chess_rules

--- a/game_logic.lua
+++ b/game_logic.lua
@@ -3,6 +3,22 @@ local chess_rules = require("chess_rules")
 
 local game_logic = {}
 
+
+function game_logic.updateLastMove(moved_piece, from_row, from_col, is_two_square_adv)
+    if moved_piece then
+        _G.lastMove = {
+            piece = moved_piece, -- Reference to the piece object
+            fromRow = from_row,
+            fromCol = from_col,
+            toRow = moved_piece.row, -- Updated row
+            toCol = moved_piece.col, -- Updated col
+            isTwoSquarePawnAdvance = is_two_square_adv
+        }
+    else
+        _G.lastMove = nil
+    end
+end
+
 function game_logic.handleClick(x, y, button, pieces, selectedPiece, currentPlayer)
     if button == 1 then
         local col = math.floor((x - config.BOARD_OFFSET_X) / config.TILE_SIZE) + 1
@@ -10,33 +26,97 @@ function game_logic.handleClick(x, y, button, pieces, selectedPiece, currentPlay
         
         if col >= 1 and col <= config.BOARD_SIZE and row >= 1 and row <= config.BOARD_SIZE then
             if selectedPiece then
-                if chess_rules.isValidMove(pieces, selectedPiece, row, col) and 
-                   not chess_rules.wouldMoveLeaveKingInCheck(pieces, selectedPiece, row, col) then
-                    game_logic.movePiece(pieces, selectedPiece, row, col)
-                    currentPlayer = currentPlayer == "white" and "black" or "white"
+                local validMoves = chess_rules.getValidMoves(pieces, selectedPiece)
+                local chosen_move_details = nil
+                for _, move in ipairs(validMoves) do
+                    if move.row == row and move.col == col then
+                        chosen_move_details = move
+                        break
+                    end
                 end
-                selectedPiece = nil
-            else
-                local piece = pieces[row][col]
-                if piece and piece.color == currentPlayer then
-                    selectedPiece = piece
+
+                if chosen_move_details then
+                    local fromRow, fromCol = selectedPiece.row, selectedPiece.col
+                    local pieceTypeBeforeMove = selectedPiece.type
+
+                    game_logic.movePiece(pieces, selectedPiece, row, col, chosen_move_details)
+
+                    local isTwoSquareAdvance = (pieceTypeBeforeMove == "pawn" and math.abs(row - fromRow) == 2)
+                    game_logic.updateLastMove(selectedPiece, fromRow, fromCol, isTwoSquareAdvance)
+
+                    if selectedPiece.promotion_pending then
+                        return nil, currentPlayer, selectedPiece
+                    else
+                        local nextPlayer = currentPlayer == "white" and "black" or "white"
+                        return nil, nextPlayer, nil
+                    end
+                else
+                    -- Clicked on a square that is not a valid move for the selected piece
+                    -- Deselect if clicked on empty or opponent's piece, otherwise keep selection
+                    if not pieces[row][col] or pieces[row][col].color ~= currentPlayer then
+                        game_logic.updateLastMove(nil) -- Clear last move as no move was made
+                        return nil, currentPlayer, nil
+                    elseif pieces[row][col] and pieces[row][col].color == currentPlayer then
+                         -- Clicked on another of own pieces, select that one instead
+                        game_logic.updateLastMove(nil) -- Clear last move
+                        return pieces[row][col], currentPlayer, nil
+                    end
+                    return selectedPiece, currentPlayer, nil -- Should not be reached often
+                end
+            else -- No piece was selected, try to select one
+                local piece_at_click = pieces[row][col]
+                if piece_at_click and piece_at_click.color == currentPlayer then
+                    game_logic.updateLastMove(nil) -- Clear last move as no move was made yet
+                    return piece_at_click, currentPlayer, nil
                 end
             end
-        else
-            selectedPiece = nil
+        else -- Clicked outside board
+            game_logic.updateLastMove(nil) -- Clear last move
+            return nil, currentPlayer, nil
         end
     end
-    
-    return selectedPiece, currentPlayer
+    -- No action for other buttons or if conditions not met, maintain current selection
+    -- and don't clear lastMove if it was from a previous successful turn.
+    return selectedPiece, currentPlayer, nil
 end
 
-function game_logic.movePiece(pieces, piece, newRow, newCol)
+function game_logic.movePiece(pieces, piece, newRow, newCol, move_details)
     if not piece then return end
     
-    pieces[piece.row][piece.col] = nil
+    local originalRow, originalCol = piece.row, piece.col -- Capture original position
+
+    pieces[originalRow][originalCol] = nil
     pieces[newRow][newCol] = piece
     piece.row = newRow
     piece.col = newCol
+    piece.has_moved = true -- Set has_moved flag for the piece that moved
+
+    -- En Passant capture: Remove the captured pawn
+    if move_details and move_details.en_passant_details then
+        local ep_pos = move_details.en_passant_details.captured_pawn_pos
+        if pieces[ep_pos.row] and pieces[ep_pos.row][ep_pos.col] then
+            pieces[ep_pos.row][ep_pos.col] = nil
+        end
+    -- Castling: Move the rook
+    elseif move_details and move_details.castling_details then
+        local cd = move_details.castling_details
+        local rook = pieces[newRow][cd.rook_original_col] -- King's row (newRow) is rook's row
+        if rook then -- Rook should definitely exist here if validation passed
+            pieces[newRow][cd.rook_original_col] = nil
+            pieces[newRow][cd.rook_target_col] = rook
+            rook.col = cd.rook_target_col
+            rook.has_moved = true
+        end
+    end
+
+    -- Pawn Promotion Logic
+    piece.promotion_pending = false -- Default
+    if piece.type == "pawn" then
+        if (piece.color == "white" and newRow == 1) or
+           (piece.color == "black" and newRow == config.BOARD_SIZE) then
+            piece.promotion_pending = true
+        end
+    end
 end
 
 return game_logic

--- a/main.lua
+++ b/main.lua
@@ -3,6 +3,7 @@ local board = require("board")
 local menu = require("menu")
 local game_renderer = require("game_renderer")
 local game_logic = require("game_logic")
+local chess_rules = require("chess_rules") -- Added for isCheckmate
 
 local pieces = {}
 local pieceImages = {}
@@ -12,6 +13,14 @@ local selectedPiece = nil
 local currentPlayer = "white"
 local gameState = "menu"
 local gameStarted = false
+local gameOverMessage = "" -- Added for checkmate message
+local promotionPiece = nil -- Piece pending promotion
+local promotionUI = { -- UI elements for pawn promotion
+    show = false,
+    options = {"queen", "rook", "bishop", "knight"},
+    selectedOption = nil, -- Currently hovered or selected
+    optionRects = {} -- To store clickable areas for UI options
+}
 
 function love.load()
     love.window.setTitle("Chess Game")
@@ -30,6 +39,7 @@ function love.load()
     end
     
     menu.updateButtons(gameStarted)
+    _G.lastMove = nil -- Initialize lastMove information
 end
 
 function love.draw()
@@ -37,6 +47,37 @@ function love.draw()
         menu.draw(bgImage, pieceImages, gameStarted)
     elseif gameState == "playing" then
         game_renderer.drawGame(boardImage, pieces, pieceImages, selectedPiece, currentPlayer)
+    elseif gameState == "pawn_promotion" then
+        game_renderer.drawGame(boardImage, pieces, pieceImages, nil, currentPlayer) -- Draw board, no selected piece highlighted
+        -- Draw promotion UI
+        local uiX = config.BOARD_WIDTH / 2 - 100
+        local uiY = config.BOARD_HEIGHT / 2 - 80
+        local optionHeight = 40
+        local padding = 5
+        love.graphics.setColor(0.2, 0.2, 0.2, 0.9) -- Dark semi-transparent background for UI
+        love.graphics.rectangle("fill", uiX, uiY, 200, #promotionUI.options * (optionHeight + padding) + padding)
+
+        promotionUI.optionRects = {} -- Clear previous rects
+        for i, optionType in ipairs(promotionUI.options) do
+            local rectY = uiY + (i-1) * (optionHeight + padding) + padding
+            local rect = {x = uiX + padding, y = rectY, width = 200 - 2 * padding, height = optionHeight}
+            table.insert(promotionUI.optionRects, rect)
+
+            love.graphics.setColor(0.4, 0.4, 0.4)
+            if promotionUI.selectedOption == optionType then -- Basic hover/selection indication
+                love.graphics.setColor(0.6, 0.6, 0.6)
+            end
+            love.graphics.rectangle("fill", rect.x, rect.y, rect.width, rect.height)
+
+            love.graphics.setColor(1, 1, 1)
+            love.graphics.printf(optionType, rect.x, rect.y + optionHeight / 2 - 7, rect.width, "center")
+        end
+    elseif gameState == "game_over" then -- Handles checkmate and stalemate
+        game_renderer.drawGame(boardImage, pieces, pieceImages, selectedPiece, currentPlayer) -- Draw board
+        love.graphics.setColor(0, 0, 0, 0.7) -- Semi-transparent black background for text
+        love.graphics.rectangle("fill", 0, config.BOARD_HEIGHT / 2 - 30, config.BOARD_WIDTH, 60)
+        love.graphics.setColor(1, 1, 1) -- White text
+        love.graphics.printf(gameOverMessage, 0, config.BOARD_HEIGHT / 2 - 10, config.BOARD_WIDTH, "center")
     end
 end
 
@@ -44,7 +85,7 @@ function love.mousepressed(x, y, button)
     if gameState == "menu" then
         local action = menu.handleClick(x, y, button)
         if action == "playing" then
-            if not gameStarted or not next(pieces) then
+            if not gameStarted or not next(pieces) then -- Resume game
                 pieces = board.initialize()
                 currentPlayer = "white"
                 selectedPiece = nil
@@ -57,9 +98,71 @@ function love.mousepressed(x, y, button)
             currentPlayer = "white"
             selectedPiece = nil
             gameStarted = true
+            gameOverMessage = "" -- Reset game over message
         end
     elseif gameState == "playing" then
-        selectedPiece, currentPlayer = game_logic.handleClick(x, y, button, pieces, selectedPiece, currentPlayer)
+        local newSelectedPiece, newCurrentPlayer, pendingPromotionPiece = game_logic.handleClick(x, y, button, pieces, selectedPiece, currentPlayer)
+        selectedPiece = newSelectedPiece
+
+        if pendingPromotionPiece then
+            gameState = "pawn_promotion"
+            promotionPiece = pendingPromotionPiece
+            promotionUI.show = true
+            selectedPiece = nil -- Clear selection during promotion
+            -- currentPlayer is NOT switched yet
+        else
+            -- Only switch player and check for game end if a move actually happened (selectedPiece is nil)
+            -- and it's not just a re-selection or invalid click.
+            -- newCurrentPlayer would be different from currentPlayer if a move was made and player switched.
+            if currentPlayer ~= newCurrentPlayer or (selectedPiece == nil and newCurrentPlayer == currentPlayer) then
+                 -- (selectedPiece == nil and newCurrentPlayer == currentPlayer) covers cases where a piece was deselected by clicking elsewhere
+                 -- if a move was made, selectedPiece would be nil and newCurrentPlayer would be the next player.
+                local moveMade = currentPlayer ~= newCurrentPlayer
+                currentPlayer = newCurrentPlayer
+
+                if moveMade then -- Only check for checkmate/stalemate if a move was actually made
+                    if chess_rules.isCheckmate(pieces, currentPlayer) then
+                        gameState = "game_over"
+                        local winner = currentPlayer == "white" and "Black" or "White"
+                        gameOverMessage = "Checkmate! " .. winner .. " wins!"
+                    elseif chess_rules.isStalemate(pieces, currentPlayer) then
+                        gameState = "game_over"
+                        gameOverMessage = "Stalemate! The game is a draw."
+                    end
+                end
+            end
+        end
+    elseif gameState == "pawn_promotion" then
+        for i, rect in ipairs(promotionUI.optionRects) do
+            if x >= rect.x and x <= rect.x + rect.width and y >= rect.y and y <= rect.y + rect.height then
+                local chosenType = promotionUI.options[i]
+                promotionPiece.type = chosenType
+                if promotionPiece.promotion_pending then promotionPiece.promotion_pending = false end
+
+                promotionUI.show = false
+                gameState = "playing"
+
+                -- NOW switch player
+                currentPlayer = currentPlayer == "white" and "black" or "white"
+
+                -- And NOW check for checkmate/stalemate for the new current player
+                if chess_rules.isCheckmate(pieces, currentPlayer) then
+                    gameState = "game_over"
+                    local winner = currentPlayer == "white" and "Black" or "White"
+                    gameOverMessage = "Checkmate! " .. winner .. " wins!"
+                elseif chess_rules.isStalemate(pieces, currentPlayer) then
+                    gameState = "game_over"
+                    gameOverMessage = "Stalemate! The game is a draw."
+                end
+
+                promotionPiece = nil
+                break
+            end
+        end
+    elseif gameState == "game_over" then -- Handles both checkmate and stalemate
+        gameState = "menu"
+        gameStarted = false -- Allow starting a new game
+        menu.updateButtons(gameStarted)
     end
 end
 
@@ -74,6 +177,12 @@ function love.keypressed(key)
         if gameState == "playing" then
             gameState = "menu"
             menu.updateButtons(gameStarted)
+        elseif gameState == "game_over" then -- Handles checkmate and stalemate
+            gameState = "menu"
+            gameStarted = false -- Allow starting a new game
+            menu.updateButtons(gameStarted)
+        -- No specific key handling for pawn_promotion, escape will not exit it.
+        -- User must choose a piece or click escape to go to menu (if that's added for playing state)
         end
     end
 end


### PR DESCRIPTION
This commit addresses several issues and missing features in the chess game logic:

- **Pawn Attack Logic:** Corrected `isSquareUnderAttack` to accurately reflect that pawns only attack diagonally forward.
- **Checkmate Detection:** Implemented `isCheckmate` to correctly identify checkmate situations. The game now ends and declares a winner.
- **Stalemate Detection:** Implemented `isStalemate` to correctly identify stalemate situations. The game now ends and declares a draw.
- **Pawn Promotion:** Added functionality for pawn promotion. When a pawn reaches the opponent's back rank, you can choose to promote it to a Queen, Rook, Bishop, or Knight. Includes UI for selection.
- **En Passant:** Implemented the en passant rule, including tracking the necessary conditions from the previous move, validating the en passant capture, and correctly removing the captured pawn.
- **Castling:** Implemented kingside and queenside castling. This includes:
    - Tracking whether the king and relevant rooks have moved.
    - Validating all conditions for castling (path clear, king not in check, squares not under attack).
    - Correctly moving both the king and the rook.
- **Piece State:** Added `has_moved` flag to pieces, essential for castling and potentially other future rules.

The core game loop in `main.lua` has been updated to incorporate these rules, manage game states (playing, pawn_promotion, game_over), and display appropriate messages. The `chess_rules.lua` and `game_logic.lua` files contain the bulk of the new and modified logic.